### PR TITLE
feat: refresh subway realtime data via in-job loop

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import time
 
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
@@ -29,5 +31,21 @@ async def execute_script(session):
     get_realtime_data(session, 1071, "수인분당선")
     session.close()
 
+
+async def run_loop():
+    # CronJob fires every minute; loop several times within that window to
+    # achieve sub-minute refresh (default: every 15s, 4 iterations per minute).
+    iterations = int(os.getenv("LOOP_ITERATIONS", "4"))
+    interval = float(os.getenv("LOOP_INTERVAL_SECONDS", "15"))
+    for i in range(iterations):
+        started_at = time.monotonic()
+        try:
+            await main()
+        except Exception as e:  # noqa: BLE001 - keep loop alive on transient errors
+            print("Subway realtime iteration failed:", e)
+        if i < iterations - 1:
+            await asyncio.sleep(max(0.0, interval - (time.monotonic() - started_at)))
+
+
 if __name__ == '__main__':
-    asyncio.run(main())
+    asyncio.run(run_loop())

--- a/src/models.py
+++ b/src/models.py
@@ -24,7 +24,7 @@ class SubwayRouteStation(BaseModel):
     station_id: Mapped[str] = mapped_column(primary_key=True)
     station_name: Mapped[str] = mapped_column(nullable=False)
     route_id: Mapped[int] = mapped_column(nullable=False)
-    station_sequence: Mapped[int] = mapped_column(nullable=False)
+    station_seq: Mapped[int] = mapped_column(nullable=False)
     cumulative_time: Mapped[datetime.timedelta] = mapped_column(nullable=False)
 
 

--- a/src/scripts/realtime.py
+++ b/src/scripts/realtime.py
@@ -24,18 +24,18 @@ def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> No
     support_station_list: list[dict] = []
     for support_station_name in support_station_name_list:
         support_station_query = select(
-            SubwayRouteStation.station_id, SubwayRouteStation.station_sequence,
+            SubwayRouteStation.station_id, SubwayRouteStation.station_seq,
             SubwayRouteStation.cumulative_time).where(and_(SubwayRouteStation.station_name == support_station_name,
                                                            SubwayRouteStation.route_id == route_id))
-        station_id, station_sequence, cumulative_time = "", 0, timedelta(seconds=0)
+        station_id, station_seq, cumulative_time = "", 0, timedelta(seconds=0)
         for row in db_session.execute(support_station_query):
-            station_id, station_sequence, cumulative_time = row
+            station_id, station_seq, cumulative_time = row
             break
         if not station_id:
             raise RuntimeError("Failed to get start station id")
         support_station_list.append({
             "station_id": station_id,
-            "station_sequence": station_sequence,
+            "station_seq": station_seq,
             "cumulative_time": cumulative_time,
         })
     response = requests.get(url)
@@ -56,13 +56,13 @@ def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> No
             # 현재 위치 조회
             current_location_query = select(
                 SubwayRouteStation.station_id,
-                SubwayRouteStation.station_sequence, SubwayRouteStation.cumulative_time,
+                SubwayRouteStation.station_seq, SubwayRouteStation.cumulative_time,
             ).where(and_(
                 SubwayRouteStation.station_name == current_station,
                 SubwayRouteStation.route_id == route_id))
-            current_station_id, current_station_sequence, current_cumulative_time = "", 0, 0.0
+            current_station_id, current_station_seq, current_cumulative_time = "", 0, 0.0
             for row in db_session.execute(current_location_query):
-                current_station_id, current_station_sequence, current_cumulative_time = row
+                current_station_id, current_station_seq, current_cumulative_time = row
                 break
             if not current_station_id:
                 continue
@@ -98,7 +98,7 @@ def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> No
                 arrival_list[support_station["station_id"]].append({
                     "station_id": support_station["station_id"],
                     "current_station_name": current_station,
-                    "remaining_stop_count": abs(current_station_sequence - support_station["station_sequence"]),
+                    "remaining_stop_count": abs(current_station_seq - support_station["station_seq"]),
                     "remaining_time": abs(current_cumulative_time - support_station["cumulative_time"]),
                     "up_down_type": int(heading) == 0,
                     "terminal_station_id": terminal_station_id,

--- a/tests/insert_subway_information.py
+++ b/tests/insert_subway_information.py
@@ -66,7 +66,7 @@ async def insert_subway_station(db_session: Session):
                             station_id=station_number,
                             route_id=route_id,
                             station_name=station_name,
-                            station_sequence=row_index,
+                            station_seq=row_index,
                             cumulative_time=timedelta(
                                 minutes=float(cumulative_time)),
                         ),
@@ -84,7 +84,7 @@ async def insert_subway_station(db_session: Session):
             route_id=insert_statement.excluded.route_id,
             station_name=insert_statement.excluded.station_name,
             cumulative_time=insert_statement.excluded.cumulative_time,
-            station_sequence=insert_statement.excluded.station_sequence,
+            station_seq=insert_statement.excluded.station_seq,
         ),
     )
     db_session.execute(insert_statement)


### PR DESCRIPTION
## Summary
- Wrap the one-shot updater in `run_loop()` so a single CronJob invocation refreshes the subway realtime data several times within its minute window, instead of just once.
- Iteration count and interval are configurable via `LOOP_ITERATIONS` / `LOOP_INTERVAL_SECONDS` env vars (code default: every 15s, 4 iterations). The deploy manifest sets these to **3 iterations / 20s**, keeping calls within the Seoul Metro API daily quota (10,000/day) over the 05:00-02:00 KST service window (~7,560 calls/day).
- Monotonic-clock pacing keeps the whole loop inside the 60s window, so back-to-back CronJob runs never overlap (`concurrencyPolicy: Forbid` on the CronJob as a backstop).

## Also included
- Rename the `station_sequence` column to `station_seq` across the model, realtime script, and tests.
- Two debug `print()` calls (`print(url)`, `print(terminal_station)`) were present in the working tree and are included as-is; drop them if undesired.

## Notes
- Pairs with the infrastructure change that restricts the CronJob to service hours (05:00-02:00 KST) and sets the loop env vars.