### PR TITLE
[codex] Fix subway realtime schema mapping

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -31,11 +31,11 @@ class SubwayRouteStation(BaseModel):
 class SubwayRealtime(BaseModel):
     __tablename__ = "subway_realtime"
     __table_args__ = (
-        PrimaryKeyConstraint("station_id", "up_down_type", "arrival_sequence"),
+        PrimaryKeyConstraint("station_id", "up_down_type", "arrival_seq"),
     )
     station_id: Mapped[str] = mapped_column(nullable=False)
     up_down_type: Mapped[str] = mapped_column(nullable=False)
-    arrival_sequence: Mapped[int] = mapped_column(nullable=False)
+    arrival_seq: Mapped[int] = mapped_column(nullable=False)
     remaining_stop_count: Mapped[int] = mapped_column(nullable=False)
     remaining_time: Mapped[datetime.timedelta] = mapped_column(nullable=False)
     terminal_station_id: Mapped[str] = mapped_column(nullable=False)

--- a/src/scripts/realtime.py
+++ b/src/scripts/realtime.py
@@ -100,7 +100,7 @@ def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> No
                     "current_station_name": current_station,
                     "remaining_stop_count": abs(current_station_seq - support_station["station_seq"]),
                     "remaining_time": abs(current_cumulative_time - support_station["cumulative_time"]),
-                    "up_down_type": int(heading) == 0,
+                    "up_down_type": heading,
                     "terminal_station_id": terminal_station_id,
                     "train_number": train_number,
                     "last_updated_time": updated_at,
@@ -111,11 +111,11 @@ def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> No
     up_arrival_sequence, down_arrival_sequence = 0, 0
     for station_id in arrival_list.keys():
         for arrival_item in sorted(arrival_list[station_id], key=lambda x: x["remaining_time"]):
-            if arrival_item["up_down_type"]:
-                arrival_item["arrival_sequence"] = up_arrival_sequence
+            if int(arrival_item["up_down_type"]) == 0:
+                arrival_item["arrival_seq"] = up_arrival_sequence
                 up_arrival_sequence += 1
             else:
-                arrival_item["arrival_sequence"] = down_arrival_sequence
+                arrival_item["arrival_seq"] = down_arrival_sequence
                 down_arrival_sequence += 1
         db_session.execute(delete(SubwayRealtime).where(SubwayRealtime.station_id == station_id))
         if arrival_list[station_id]:

--- a/tests/test_subway_data.py
+++ b/tests/test_subway_data.py
@@ -48,7 +48,7 @@ class TestFetchRealtimeData:
         for arrival_item in arrival_list:  # type: SubwayRealtime
             assert isinstance(arrival_item.station_id, str)
             assert isinstance(arrival_item.up_down_type, str)
-            assert isinstance(arrival_item.arrival_sequence, int)
+            assert isinstance(arrival_item.arrival_seq, int)
             assert isinstance(arrival_item.remaining_stop_count, int)
             assert isinstance(arrival_item.remaining_time, datetime.timedelta)
             assert isinstance(arrival_item.terminal_station_id, str)


### PR DESCRIPTION
## Summary
- align `SubwayRealtime` ORM mapping with the infrastructure database schema
- write realtime arrival order to `arrival_seq` instead of the non-existent `arrival_sequence` column
- store `up_down_type` as the Seoul Metro heading string instead of a boolean

## Root cause
The updater generated INSERT statements for `subway_realtime.arrival_sequence`, but the infrastructure schema and backend entity both define the column as `arrival_seq`. The updater also inserted a boolean into `up_down_type`, while the database and backend treat it as a varchar heading.

## Validation
- `python -m compileall src tests`
- `python -m flake8 src tests`
- compiled SQLAlchemy INSERT and confirmed it targets `arrival_seq`

`python -m pytest` could not complete locally because the configured PostgreSQL host `192.168.50.113:5432` timed out before test setup.
