### PR TITLE
feat: Add Seohae Line realtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ A recurring job that fetches real-time subway arrival information and keeps the 
 
 ## Overview
 
-On each run the job queries the Seoul Metro open API for real-time arrival data for the two lines serving Hanyang University ERICA:
+On each run the job queries the Seoul Metro open API for real-time arrival data for the lines serving Hanyang University ERICA:
 
 - **Line 4** (route ID: 1004) — Hanyang University station
 - **Suin-Bundang Line** (route ID: 1071) — Sangnoksu station
+- **Seohae Line** (route ID: 1093) — Choji station
 
 The job clears stale `subway_realtime` records and inserts fresh arrival predictions. Supports master-DB failover.
 

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ async def main():
 async def execute_script(session):
     get_realtime_data(session, 1004, "4호선")
     get_realtime_data(session, 1071, "수인분당선")
+    get_realtime_data(session, 1093, "서해선")
     session.close()
 
 

--- a/src/scripts/realtime.py
+++ b/src/scripts/realtime.py
@@ -9,6 +9,13 @@ from sqlalchemy.orm import Session
 from models import SubwayRealtime, SubwayRouteStation
 
 
+SUPPORT_STATION_NAMES_BY_ROUTE_ID = {
+    1004: ["한대앞", "오이도"],
+    1071: ["한대앞", "오이도"],
+    1093: ["초지"],
+}
+
+
 def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> None:
     auth_key = os.getenv("METRO_AUTH_KEY")
     if auth_key is None:
@@ -20,7 +27,7 @@ def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> No
           f"realtimePosition/0/{count}/{route_name}"
     arrival_list: dict[str, list[dict]] = {}
     train_number_list: dict[str, list[str]] = {}
-    support_station_name_list: list[str] = ["한대앞", "오이도"]
+    support_station_name_list = SUPPORT_STATION_NAMES_BY_ROUTE_ID.get(route_id, [])
     support_station_list: list[dict] = []
     for support_station_name in support_station_name_list:
         support_station_query = select(
@@ -68,22 +75,25 @@ def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> No
                 continue
 
             # 종착역 조회
-            terminal_station_query = select(SubwayRouteStation.station_id).where(and_(
+            terminal_station_query = select(
+                SubwayRouteStation.station_id,
+                SubwayRouteStation.station_seq,
+            ).where(and_(
                 SubwayRouteStation.station_name == terminal_station,
                 SubwayRouteStation.route_id == route_id))
-            terminal_station_id = ""
+            terminal_station_id, terminal_station_seq = "", 0
             for terminal_station_item in db_session.execute(terminal_station_query):
-                terminal_station_id = terminal_station_item[0]
+                terminal_station_id, terminal_station_seq = terminal_station_item
                 break
             if not terminal_station_id:
                 continue
             for support_station_index, support_station in enumerate(support_station_list):
                 # 데이터 추가
                 if int(heading) == 0 and \
-                        not (terminal_station_id <= support_station["station_id"] < current_station_id):
+                        not (terminal_station_seq <= support_station["station_seq"] < current_station_seq):
                     continue
                 elif int(heading) == 1 and \
-                        not (current_station_id < support_station["station_id"] <= terminal_station_id):
+                        not (current_station_seq < support_station["station_seq"] <= terminal_station_seq):
                     continue
                 if support_station["station_id"] not in arrival_list.keys():
                     arrival_list[support_station["station_id"]] = []

--- a/src/scripts/realtime.py
+++ b/src/scripts/realtime.py
@@ -75,25 +75,22 @@ def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> No
                 continue
 
             # 종착역 조회
-            terminal_station_query = select(
-                SubwayRouteStation.station_id,
-                SubwayRouteStation.station_seq,
-            ).where(and_(
+            terminal_station_query = select(SubwayRouteStation.station_id).where(and_(
                 SubwayRouteStation.station_name == terminal_station,
                 SubwayRouteStation.route_id == route_id))
-            terminal_station_id, terminal_station_seq = "", 0
+            terminal_station_id = ""
             for terminal_station_item in db_session.execute(terminal_station_query):
-                terminal_station_id, terminal_station_seq = terminal_station_item
+                terminal_station_id = terminal_station_item[0]
                 break
             if not terminal_station_id:
                 continue
             for support_station_index, support_station in enumerate(support_station_list):
                 # 데이터 추가
                 if int(heading) == 0 and \
-                        not (terminal_station_seq <= support_station["station_seq"] < current_station_seq):
+                        not (terminal_station_id <= support_station["station_id"] < current_station_id):
                     continue
                 elif int(heading) == 1 and \
-                        not (current_station_seq < support_station["station_seq"] <= terminal_station_seq):
+                        not (current_station_id < support_station["station_id"] <= terminal_station_id):
                     continue
                 if support_station["station_id"] not in arrival_list.keys():
                     arrival_list[support_station["station_id"]] = []

--- a/tests/insert_subway_information.py
+++ b/tests/insert_subway_information.py
@@ -28,6 +28,7 @@ async def insert_subway_route(db_session: Session):
         dict(route_id=1077, route_name="신분당선"),
         dict(route_id=1091, route_name="자기부상선"),
         dict(route_id=1092, route_name="우이신설선"),
+        dict(route_id=1093, route_name="서해선"),
         dict(route_id=1163, route_name="경의중앙선"),
         dict(route_id=1165, route_name="공항철도"),
         dict(route_id=1167, route_name="경춘선"),
@@ -39,6 +40,21 @@ async def insert_subway_route(db_session: Session):
     )
     db_session.execute(insert_statement)
     db_session.commit()
+
+
+def insert_local_station_data(route_id: int, station_rows: list[tuple[str, str, float]]) -> list[dict]:
+    station_list: list[dict] = []
+    for row_index, (station_number, station_name, cumulative_time) in enumerate(station_rows):
+        station_list.append(
+            dict(
+                station_id=station_number,
+                route_id=route_id,
+                station_name=station_name,
+                station_seq=row_index,
+                cumulative_time=timedelta(minutes=cumulative_time),
+            ),
+        )
+    return station_list
 
 
 async def insert_subway_station(db_session: Session):
@@ -72,6 +88,25 @@ async def insert_subway_station(db_session: Session):
                         ),
                     )
                     station_name_list.append(dict(station_name=station_name))
+    seohae_station_list = insert_local_station_data(
+        1093,
+        [
+            ("S16", "원시", 0),
+            ("S17", "시우", 2),
+            ("S18", "초지", 5),
+            ("S19", "선부", 8),
+            ("S20", "달미", 11),
+            ("S21", "시흥능곡", 14),
+            ("S22", "시흥시청", 17),
+            ("S23", "신현", 20),
+            ("S24", "신천", 23),
+            ("S25", "시흥대야", 26),
+            ("S26", "소새울", 29),
+            ("S27", "소사", 32),
+        ],
+    )
+    station_list.extend(seohae_station_list)
+    station_name_list.extend(dict(station_name=row["station_name"]) for row in seohae_station_list)
     insert_statement = insert(SubwayStation).values(station_name_list)
     insert_statement = insert_statement.on_conflict_do_nothing()
     db_session.execute(insert_statement)

--- a/tests/test_subway_data.py
+++ b/tests/test_subway_data.py
@@ -42,6 +42,7 @@ class TestFetchRealtimeData:
         session.execute(delete(SubwayRealtime))
         get_realtime_data(session, 1004, "4호선")
         get_realtime_data(session, 1071, "수인분당선")
+        get_realtime_data(session, 1093, "서해선")
 
         # Check if the data is inserted
         arrival_list = session.query(SubwayRealtime).all()


### PR DESCRIPTION
## Summary
- Add Seohae Line support to realtime subway updates.
- Keep existing supported line behavior unchanged.
- Use route-specific support stations for realtime target selection.
- Add coverage for the new supported line.

## Validation
- Static checks passed.
- Realtime updater test passed with the corrected database host.

## Notes
- Type checking was not run because the local environment is missing the required tool.
