### PR TITLE
Add first-runner label to deployment job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   docker-image-build:
-    runs-on: [ self-hosted, ARM64, Linux ]
+    runs-on: [ self-hosted, ARM64, Linux, 1st ]
     env:
       IMAGE_NAME: localhost:5000/hyuabot-subway-realtime-updater:latest
     steps:


### PR DESCRIPTION
## Summary
- Restrict the deployment job to runners with the required first-runner label.
- Leave code check jobs unchanged.

## Validation
- Confirmed the final change is limited to deployment runner selection.
