### PR TITLE
fix: Clear stale subway realtime data

### DIFF
--- a/src/scripts/realtime.py
+++ b/src/scripts/realtime.py
@@ -45,76 +45,88 @@ def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> No
             "station_seq": station_seq,
             "cumulative_time": cumulative_time,
         })
-    response = requests.get(url)
+    response = requests.get(url, timeout=5)
+    response.raise_for_status()
     response_json = response.json()
+    realtime_position_list = response_json.get("realtimePositionList")
+    if realtime_position_list is None:
+        result_code = response_json.get("RESULT", {}).get("CODE")
+        error_code = response_json.get("errorMessage", {}).get("code")
+        if result_code == "INFO-200" or error_code == "INFO-200":
+            realtime_position_list = []
+        else:
+            raise RuntimeError("Subway realtime API returned an unsuccessful response")
+    if not isinstance(realtime_position_list, list):
+        raise RuntimeError("Subway realtime API returned an invalid realtimePositionList")
     kst = timezone("Asia/Seoul")
-    if "realtimePositionList" in response_json.keys():
-        realtime_position_list = response_json["realtimePositionList"]
-        for realtime_position_item in realtime_position_list:
-            current_station = realtime_position_item["statnNm"]
-            train_number = realtime_position_item["trainNo"]
-            updated_time = realtime_position_item["recptnDt"]
-            heading = realtime_position_item["updnLine"]
-            terminal_station = realtime_position_item["statnTnm"]
-            status_code = realtime_position_item["trainSttus"]
-            is_express_train = realtime_position_item["directAt"]
-            is_last_train = realtime_position_item["lstcarAt"]
+    for realtime_position_item in realtime_position_list:
+        current_station = realtime_position_item["statnNm"]
+        train_number = realtime_position_item["trainNo"]
+        updated_time = realtime_position_item["recptnDt"]
+        heading = realtime_position_item["updnLine"]
+        terminal_station = realtime_position_item["statnTnm"]
+        status_code = realtime_position_item["trainSttus"]
+        is_express_train = realtime_position_item["directAt"]
+        is_last_train = realtime_position_item["lstcarAt"]
 
-            # 현재 위치 조회
-            current_location_query = select(
-                SubwayRouteStation.station_id,
-                SubwayRouteStation.station_seq, SubwayRouteStation.cumulative_time,
-            ).where(and_(
-                SubwayRouteStation.station_name == current_station,
-                SubwayRouteStation.route_id == route_id))
-            current_station_id, current_station_seq, current_cumulative_time = "", 0, 0.0
-            for row in db_session.execute(current_location_query):
-                current_station_id, current_station_seq, current_cumulative_time = row
-                break
-            if not current_station_id:
-                continue
+        # 현재 위치 조회
+        current_location_query = select(
+            SubwayRouteStation.station_id,
+            SubwayRouteStation.station_seq, SubwayRouteStation.cumulative_time,
+        ).where(and_(
+            SubwayRouteStation.station_name == current_station,
+            SubwayRouteStation.route_id == route_id))
+        current_station_id, current_station_seq, current_cumulative_time = "", 0, 0.0
+        for row in db_session.execute(current_location_query):
+            current_station_id, current_station_seq, current_cumulative_time = row
+            break
+        if not current_station_id:
+            continue
 
-            # 종착역 조회
-            terminal_station_query = select(SubwayRouteStation.station_id).where(and_(
-                SubwayRouteStation.station_name == terminal_station,
-                SubwayRouteStation.route_id == route_id))
-            terminal_station_id = ""
-            for terminal_station_item in db_session.execute(terminal_station_query):
-                terminal_station_id = terminal_station_item[0]
-                break
-            if not terminal_station_id:
+        # 종착역 조회
+        terminal_station_query = select(SubwayRouteStation.station_id).where(and_(
+            SubwayRouteStation.station_name == terminal_station,
+            SubwayRouteStation.route_id == route_id))
+        terminal_station_id = ""
+        for terminal_station_item in db_session.execute(terminal_station_query):
+            terminal_station_id = terminal_station_item[0]
+            break
+        if not terminal_station_id:
+            continue
+        for support_station_index, support_station in enumerate(support_station_list):
+            # 데이터 추가
+            if int(heading) == 0 and \
+                    not (terminal_station_id <= support_station["station_id"] < current_station_id):
                 continue
-            for support_station_index, support_station in enumerate(support_station_list):
-                # 데이터 추가
-                if int(heading) == 0 and \
-                        not (terminal_station_id <= support_station["station_id"] < current_station_id):
-                    continue
-                elif int(heading) == 1 and \
-                        not (current_station_id < support_station["station_id"] <= terminal_station_id):
-                    continue
-                if support_station["station_id"] not in arrival_list.keys():
-                    arrival_list[support_station["station_id"]] = []
-                    train_number_list[support_station["station_id"]] = []
-                if train_number in train_number_list[support_station["station_id"]]:
-                    arrival_list[support_station["station_id"]].remove(
-                        arrival_list[support_station["station_id"]]
-                        [train_number_list[support_station["station_id"]].index(train_number)])
-                    train_number_list[support_station["station_id"]].remove(train_number)
-                train_number_list[support_station["station_id"]].append(train_number)
-                updated_at = kst.localize(datetime.strptime(updated_time, "%Y-%m-%d %H:%M:%S"))
-                arrival_list[support_station["station_id"]].append({
-                    "station_id": support_station["station_id"],
-                    "current_station_name": current_station,
-                    "remaining_stop_count": abs(current_station_seq - support_station["station_seq"]),
-                    "remaining_time": abs(current_cumulative_time - support_station["cumulative_time"]),
-                    "up_down_type": heading,
-                    "terminal_station_id": terminal_station_id,
-                    "train_number": train_number,
-                    "last_updated_time": updated_at,
-                    "is_express_train": is_express_train == 1,
-                    "is_last_train": is_last_train == 1,
-                    "status_code": status_code,
-                })
+            elif int(heading) == 1 and \
+                    not (current_station_id < support_station["station_id"] <= terminal_station_id):
+                continue
+            if support_station["station_id"] not in arrival_list.keys():
+                arrival_list[support_station["station_id"]] = []
+                train_number_list[support_station["station_id"]] = []
+            if train_number in train_number_list[support_station["station_id"]]:
+                arrival_list[support_station["station_id"]].remove(
+                    arrival_list[support_station["station_id"]]
+                    [train_number_list[support_station["station_id"]].index(train_number)])
+                train_number_list[support_station["station_id"]].remove(train_number)
+            train_number_list[support_station["station_id"]].append(train_number)
+            updated_at = kst.localize(datetime.strptime(updated_time, "%Y-%m-%d %H:%M:%S"))
+            arrival_list[support_station["station_id"]].append({
+                "station_id": support_station["station_id"],
+                "current_station_name": current_station,
+                "remaining_stop_count": abs(current_station_seq - support_station["station_seq"]),
+                "remaining_time": abs(current_cumulative_time - support_station["cumulative_time"]),
+                "up_down_type": heading,
+                "terminal_station_id": terminal_station_id,
+                "train_number": train_number,
+                "last_updated_time": updated_at,
+                "is_express_train": is_express_train == 1,
+                "is_last_train": is_last_train == 1,
+                "status_code": status_code,
+            })
+    support_station_id_list = [support_station["station_id"] for support_station in support_station_list]
+    if support_station_id_list:
+        db_session.execute(delete(SubwayRealtime).where(SubwayRealtime.station_id.in_(support_station_id_list)))
     up_arrival_sequence, down_arrival_sequence = 0, 0
     for station_id in arrival_list.keys():
         for arrival_item in sorted(arrival_list[station_id], key=lambda x: x["remaining_time"]):
@@ -124,7 +136,6 @@ def get_realtime_data(db_session: Session, route_id: int, route_name: str) -> No
             else:
                 arrival_item["arrival_seq"] = down_arrival_sequence
                 down_arrival_sequence += 1
-        db_session.execute(delete(SubwayRealtime).where(SubwayRealtime.station_id == station_id))
         if arrival_list[station_id]:
             insert_statement = insert(SubwayRealtime).values(arrival_list[station_id])
             db_session.execute(insert_statement)

--- a/tests/test_subway_data.py
+++ b/tests/test_subway_data.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy import delete
@@ -59,3 +60,46 @@ class TestFetchRealtimeData:
             assert isinstance(arrival_item.is_express_train, bool)
             assert isinstance(arrival_item.is_last_train, bool)
             assert isinstance(arrival_item.status_code, int)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"realtimePositionList": []},
+        {"RESULT": {"CODE": "INFO-200", "MESSAGE": "No data"}},
+        {"errorMessage": {"code": "INFO-200", "message": "No data"}},
+    ],
+)
+def test_empty_response_clears_stale_realtime_data(payload):
+    session = MagicMock(spec=Session)
+    session.execute.side_effect = [
+        [("K449", 1, datetime.timedelta())],
+        [("K258", 2, datetime.timedelta(minutes=10))],
+        MagicMock(),
+    ]
+    response = MagicMock()
+    response.json.return_value = payload
+
+    with patch("scripts.realtime.requests.get", return_value=response) as request:
+        get_realtime_data(session, 1071, "수인분당선")
+
+    request.assert_called_once()
+    assert request.call_args.kwargs["timeout"] == 5
+    response.raise_for_status.assert_called_once_with()
+    assert session.execute.call_count == 3
+    delete_statement = session.execute.call_args_list[-1].args[0]
+    assert set(delete_statement.compile().params["station_id_1"]) == {"K449", "K258"}
+    session.commit.assert_called_once_with()
+
+
+def test_unsuccessful_response_preserves_stale_realtime_data():
+    session = MagicMock(spec=Session)
+    session.execute.return_value = [("S021", 1, datetime.timedelta())]
+    response = MagicMock()
+    response.json.return_value = {"RESULT": {"CODE": "ERROR-500", "MESSAGE": "Server error"}}
+
+    with patch("scripts.realtime.requests.get", return_value=response), pytest.raises(RuntimeError):
+        get_realtime_data(session, 1093, "서해선")
+
+    assert session.execute.call_count == 1
+    session.commit.assert_not_called()


### PR DESCRIPTION
## Summary
- Clear stored realtime rows for supported stations when the Seoul Metro API returns an empty list or `INFO-200`.
- Replace each route's supported-station snapshot in one transaction.
- Preserve existing rows when the API returns an error, malformed response, or HTTP failure.
- Add a request timeout and coverage for empty and unsuccessful responses.

## Root cause
The updater only deleted rows for station IDs present in the newly built arrival map. After the last train, the API returned no positions, the map stayed empty, and the previous realtime rows were never deleted, leaving stale train information visible in the app.

## Validation
- `python -m pytest -v tests/test_subway_data.py -k 'empty_response or unsuccessful_response'`
- `python -m flake8 src/ tests/`
- `python -m mypy src/ tests/`
