### PR TITLE
fix: Publish immutable Docker images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@09bc374fafc8bf879436d8e2fed94fa178ee2b3d
+    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@accefba87348b747359be6ee4a2ed8d16ca625f6
     with:
       image-repository: localhost:5000/hyuabot-subway-realtime-updater
       workload-kind: cronjob

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@accefba87348b747359be6ee4a2ed8d16ca625f6
+    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@8f1f01759d39340962b33d8cbba4835980715a4c
     with:
       image-repository: localhost:5000/hyuabot-subway-realtime-updater
       workload-kind: cronjob

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,35 +1,27 @@
 name: Deploy Docker Image
+
 on:
   pull_request:
-    branches:
-      - main
-    types:
-      - closed
+    branches: [main]
+    types: [closed]
   workflow_dispatch:
+    inputs:
+      no-cache:
+        description: Build Docker image without using cache
+        required: false
+        default: false
+        type: boolean
+
 jobs:
-  docker-image-build:
-    runs-on: [ self-hosted, ARM64, Linux, 1st ]
-    env:
-      IMAGE_NAME: localhost:5000/hyuabot-subway-realtime-updater:latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Set up Docker Build Environment
-        uses: docker/setup-buildx-action@v4
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          load: true
-          tags: ${{ env.IMAGE_NAME }}
-          no-cache: true
-      - name: Push docker image
-        run: |
-          docker push ${{ env.IMAGE_NAME }}
-      - name: Sync image to worker registry
-        uses: hyuabot-developers/hyuabot-infrastructure/.github/actions/sync-local-registry@a091ea37f391ae60eb7828325782a397cc7cae9c
-        with:
-          image: ${{ env.IMAGE_NAME }}
-      - name: Remove docker image
-        run: |
-          docker rmi ${{ env.IMAGE_NAME }}
+  publish:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@09bc374fafc8bf879436d8e2fed94fa178ee2b3d
+    with:
+      image-repository: localhost:5000/hyuabot-subway-realtime-updater
+      workload-kind: cronjob
+      workload-name: subway-realtime-cron-job
+      container-name: subway-realtime-cron-job
+      no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs['no-cache'] }}
+    secrets:
+      RUNNER_ADMIN_TOKEN: ${{ secrets.RUNNER_ADMIN_TOKEN }}
+      FIRST_HOST: ${{ secrets.SSH_HOST || secrets.ORACLE_TRANSFER_TARGET }}


### PR DESCRIPTION
## Summary

- Build the container image with the full merge commit SHA instead of the mutable `latest` tag.
- Use the online Apple Silicon MacBook builder even while busy and fall back to the first Oracle runner only while the Mac is offline.
- Publish equivalent content to both loopback registries and remove local Docker image copies after synchronization.
- Update the live workload to the immutable image where the repository owns a recurring deployment.

## Root Cause

The deployment workflow reused `latest`, so the two node-local registries and running Pods could refer to different image content. Builds also occupied the production server even when a compatible MacBook runner was available.

## Impact

New images are traceable to a Git commit and remain stored in both registries without redundant local Docker copies. BuildKit cache remains available for subsequent builds. An online MacBook always remains selected, including while busy, so builds wait in its queue. The first server is selected only when GitHub explicitly reports the Mac as offline; selection errors fail instead of falling back.

## Validation

- Parsed `.github/workflows/deploy.yml` as YAML.
- Validated the workflow with actionlint.
- Ran `git diff --check`.
- Verified the pinned infrastructure actions with their mocked tests.
- Verified OrbStack Buildx on the ARM64 MacBook.
- Built this production image on the OrbStack ARM64 MacBook, verified `linux/arm64`, and removed the test image.